### PR TITLE
Fix schedule handling

### DIFF
--- a/blocksite_clone_updated/src/blocked.html
+++ b/blocksite_clone_updated/src/blocked.html
@@ -100,7 +100,7 @@
 </head>
 <body>
   <div class="container">
-    <img src="images/logo.png" alt="BlockSite Clone Logo" class="logo">
+    <img src="images/icon128.png" alt="BlockSite Clone Logo" class="logo">
     <h1>This site has been blocked</h1>
     <p>You've chosen to block this website to help you stay focused and productive.</p>
     <p>If you need to access this site, you can temporarily disable blocking or remove it from your block list.</p>

--- a/blocksite_clone_updated/src/insights.html
+++ b/blocksite_clone_updated/src/insights.html
@@ -8,7 +8,7 @@
 <body>
   <div class="container">
     <div class="header">
-      <img src="images/logo.png" alt="BlockSite Clone Logo" class="logo">
+      <img src="images/icon128.png" alt="BlockSite Clone Logo" class="logo">
       <h1>BlockSite Clone - Insights</h1>
       <a href="options.html" class="back-btn">Back to Settings</a>
     </div>

--- a/blocksite_clone_updated/src/js/background.js
+++ b/blocksite_clone_updated/src/js/background.js
@@ -89,9 +89,11 @@ async function checkIfShouldBlock(url, tabId) {
     
     // Check if current time matches any schedule for this domain
     const shouldBlockBySchedule = checkSchedules(settings.schedules, hostname);
-    
-    // If focus mode is enabled, always block. Otherwise, check schedule
-    const shouldBlock = settings.focusModeEnabled || shouldBlockBySchedule;
+
+    // Determine if blocking should occur
+    // If no schedules are defined, blocking should be active at all times
+    const hasSchedules = Array.isArray(settings.schedules) && settings.schedules.length > 0;
+    const shouldBlock = settings.focusModeEnabled || !hasSchedules || shouldBlockBySchedule;
     
     if (!shouldBlock) return;
     


### PR DESCRIPTION
## Summary
- default to blocking when no schedules set
- fix missing logos

## Testing
- `npm test` *(fails: ENOENT no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684b04e36918832b8924b653ab430bb2