### PR TITLE
Require password to disable blocking

### DIFF
--- a/blocksite_clone_updated/src/js/options.js
+++ b/blocksite_clone_updated/src/js/options.js
@@ -465,7 +465,19 @@ document.addEventListener('DOMContentLoaded', function() {
   
   // Event listeners
   enableBlockingToggle.addEventListener('change', function() {
-    chrome.storage.sync.set({ isEnabled: this.checked });
+    if (!this.checked) {
+      // Require password before disabling blocking
+      checkPasswordBeforeUnblocking('', (success) => {
+        if (success) {
+          chrome.storage.sync.set({ isEnabled: false });
+        } else {
+          // Revert toggle if password check failed or was canceled
+          enableBlockingToggle.checked = true;
+        }
+      });
+    } else {
+      chrome.storage.sync.set({ isEnabled: true });
+    }
   });
   
   focusModeToggle.addEventListener('change', function() {

--- a/blocksite_clone_updated/src/popup.html
+++ b/blocksite_clone_updated/src/popup.html
@@ -60,6 +60,7 @@
     </div>
   </div>
   
+  <script src="js/password-utils.js"></script>
   <script src="js/popup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load password utility in popup
- enforce password when toggling off blocking in options page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b062955e4832b85b99de73687afc3